### PR TITLE
ASCollection: implement IEnumerable

### DIFF
--- a/ActivityPub.Types/AS/Collection/ASCollection.cs
+++ b/ActivityPub.Types/AS/Collection/ASCollection.cs
@@ -100,31 +100,9 @@ public class ASCollection : ASObject, IEnumerable<Linkable<ASObject>>
 
     public static implicit operator ASCollection(List<ASObject> collection) => new() { Items = new LinkableList<ASObject>(collection) };
 
-    public IEnumerator<Linkable<ASObject>> GetEnumerator()
-    {
-        if (Items == null)
-        {
-            yield break;
-        }
+    public IEnumerator<Linkable<ASObject>> GetEnumerator() => Items?.GetEnumerator() ?? Enumerable.Empty<Linkable<ASObject>>().GetEnumerator();
 
-        foreach (var item in Items)
-        {
-            if (item.HasValue)
-            {
-                yield return item.Value;
-            }
-
-            if (item.HasLink)
-            {
-                yield return item.Link;
-            }
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }
 
 /// <inheritdoc cref="ASCollection" />

--- a/ActivityPub.Types/AS/Collection/ASCollection.cs
+++ b/ActivityPub.Types/AS/Collection/ASCollection.cs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
@@ -18,7 +19,7 @@ namespace ActivityPub.Types.AS.Collection;
 /// </remarks>
 /// <seealso href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-collection" />
 /// <seealso href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-orderedcollection" />
-public class ASCollection : ASObject
+public class ASCollection : ASObject, IEnumerable<Linkable<ASObject>>
 {
     public ASCollection() => Entity = new ASCollectionEntity { TypeMap = TypeMap };
     public ASCollection(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<ASCollectionEntity>();
@@ -98,6 +99,32 @@ public class ASCollection : ASObject
     public bool HasItems => Items?.Any() == true;
 
     public static implicit operator ASCollection(List<ASObject> collection) => new() { Items = new LinkableList<ASObject>(collection) };
+
+    public IEnumerator<Linkable<ASObject>> GetEnumerator()
+    {
+        if (Items == null)
+        {
+            yield break;
+        }
+
+        foreach (var item in Items)
+        {
+            if (item.HasValue)
+            {
+                yield return item.Value;
+            }
+
+            if (item.HasLink)
+            {
+                yield return item.Link;
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 }
 
 /// <inheritdoc cref="ASCollection" />

--- a/ActivityPub.Types/AS/Collection/ASOrderedCollection.cs
+++ b/ActivityPub.Types/AS/Collection/ASOrderedCollection.cs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
@@ -18,7 +19,7 @@ namespace ActivityPub.Types.AS.Collection;
 /// </remarks>
 /// <seealso href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-collection" />
 /// <seealso href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-orderedcollection" />
-public class ASOrderedCollection : ASObject
+public class ASOrderedCollection : ASObject, IEnumerable<Linkable<ASObject>>
 {
     public ASOrderedCollection() => Entity = new ASOrderedCollectionEntity { TypeMap = TypeMap };
     public ASOrderedCollection(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<ASOrderedCollectionEntity>();
@@ -99,6 +100,32 @@ public class ASOrderedCollection : ASObject
     public bool HasItems => Items?.Any() == true;
 
     public static implicit operator ASOrderedCollection(List<ASObject> collection) => new() { Items = new LinkableList<ASObject>(collection) };
+
+    public IEnumerator<Linkable<ASObject>> GetEnumerator()
+    {
+        if (Items == null)
+        {
+            yield break;
+        }
+
+        foreach (var item in Items)
+        {
+            if (item.HasValue)
+            {
+                yield return item.Value;
+            }
+
+            if (item.HasLink)
+            {
+                yield return item.Link;
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 }
 
 /// <inheritdoc cref="ASOrderedCollection" />

--- a/ActivityPub.Types/AS/Collection/ASOrderedCollection.cs
+++ b/ActivityPub.Types/AS/Collection/ASOrderedCollection.cs
@@ -101,31 +101,9 @@ public class ASOrderedCollection : ASObject, IEnumerable<Linkable<ASObject>>
 
     public static implicit operator ASOrderedCollection(List<ASObject> collection) => new() { Items = new LinkableList<ASObject>(collection) };
 
-    public IEnumerator<Linkable<ASObject>> GetEnumerator()
-    {
-        if (Items == null)
-        {
-            yield break;
-        }
+    public IEnumerator<Linkable<ASObject>> GetEnumerator() => Items?.GetEnumerator() ?? Enumerable.Empty<Linkable<ASObject>>().GetEnumerator();
 
-        foreach (var item in Items)
-        {
-            if (item.HasValue)
-            {
-                yield return item.Value;
-            }
-
-            if (item.HasLink)
-            {
-                yield return item.Link;
-            }
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }
 
 /// <inheritdoc cref="ASOrderedCollection" />

--- a/Tests/ActivityPub.Types.Tests/Integration/Deserialization/CollectionDeserializationTests.cs
+++ b/Tests/ActivityPub.Types.Tests/Integration/Deserialization/CollectionDeserializationTests.cs
@@ -24,6 +24,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             ObjectUnderTest.As<ASCollection>().HasItems.Should().BeTrue();
             ObjectUnderTest.As<ASCollection>().Items.Should().NotBeNull();
             ObjectUnderTest.As<ASCollection>().Items.Should().HaveCount(1);
+            ObjectUnderTest.As<ASCollection>().Should().HaveCount(1);
         }
 
         [Fact]
@@ -35,6 +36,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             ObjectUnderTest.As<ASOrderedCollection>().HasItems.Should().BeTrue();
             ObjectUnderTest.As<ASOrderedCollection>().Items.Should().NotBeNull();
             ObjectUnderTest.As<ASOrderedCollection>().Items.Should().HaveCount(1);
+            ObjectUnderTest.As<ASOrderedCollection>().Should().HaveCount(1);
         }
 
         [Fact]
@@ -46,6 +48,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             ObjectUnderTest.As<ASCollectionPage>().HasItems.Should().BeTrue();
             ObjectUnderTest.As<ASCollectionPage>().Items.Should().NotBeNull();
             ObjectUnderTest.As<ASCollectionPage>().Items.Should().HaveCount(1);
+            ObjectUnderTest.As<ASCollectionPage>().Should().HaveCount(1);
         }
 
         [Fact]
@@ -57,6 +60,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             ObjectUnderTest.As<ASOrderedCollectionPage>().HasItems.Should().BeTrue();
             ObjectUnderTest.As<ASOrderedCollectionPage>().Items.Should().NotBeNull();
             ObjectUnderTest.As<ASOrderedCollectionPage>().Items.Should().HaveCount(1);
+            ObjectUnderTest.As<ASOrderedCollectionPage>().Should().HaveCount(1);
         }
     }
 
@@ -70,6 +74,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             JsonUnderTest = """{"type":"OrderedCollection","totalItems":1,"orderedItems":[{"type":"Link","href":"https://example.com"}]}""";
             var obj = ObjectUnderTest.As<ASOrderedCollection>();
             obj.TotalItems.Should().Be(1);
+            obj.Should().HaveCount(1);
             obj.Items?.First().HasLink.Should().BeTrue();
             obj.Items?.First().Link?.HRef.Should().Be("https://example.com");
         }
@@ -81,6 +86,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             JsonUnderTest = """{"type":"OrderedCollection","totalItems":1,"orderedItems":["https://example.com"]}""";
             var obj = ObjectUnderTest.As<ASOrderedCollection>();
             obj.TotalItems.Should().Be(1);
+            obj.Should().HaveCount(1);
             obj.Items?.First().HasLink.Should().BeTrue();
             obj.Items?.First().Link?.HRef.Should().Be("https://example.com");
         }
@@ -92,6 +98,7 @@ public abstract class CollectionDeserializationTests : DeserializationTests<ASOb
             JsonUnderTest = """{"type":"OrderedCollection","totalItems":2,"orderedItems":[{},{"type":"Link","href":"https://example.com/1"},"https://example.com/2"]}""";
             var obj = ObjectUnderTest.As<ASOrderedCollection>();
             obj.TotalItems.Should().Be(2);
+            obj.Should().HaveCount(3);
             obj.Items?[0].HasValue.Should().BeTrue();
             obj.Items?[1].HasLink.Should().BeTrue();
             obj.Items?[2].HasLink.Should().BeTrue();


### PR DESCRIPTION
Resolves #43 

It does not implement the generic `IEnumerable<T>` as `OrderedCollection` is no longer generic. If we still desire it to implement a generic IEnumerable then we'll have to revert or partially revert [this](https://github.com/warriordog/ActivityPubSharp/commit/b4934308bb097ff4989832c9b9953431486e473c), but I think implementing as `IEnumerable<Linkable<ASObject>>` should hopefully not be a problem since that's what the Entity's LinkableList is essentially doing. 