### PR TITLE
chore: update names and references

### DIFF
--- a/ActivityPub.Types/AS/APActor.cs
+++ b/ActivityPub.Types/AS/APActor.cs
@@ -16,17 +16,17 @@ namespace ActivityPub.Types.AS;
 ///     It does not exist in the ActivityStreams or ActivityPub standards.
 /// </remarks>
 /// <seealso href="https://www.w3.org/TR/activitypub/#actor-objects" />
-public class ASActor : ASObject
+public class APActor : ASObject
 {
-    public ASActor() => Entity = new ASActorEntity
+    public APActor() => Entity = new APActorEntity
     {
         TypeMap = TypeMap,
         Inbox = null!,
         Outbox = null!
     };
 
-    public ASActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<ASActorEntity>();
-    private ASActorEntity Entity { get; }
+    public APActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<APActorEntity>();
+    private APActorEntity Entity { get; }
 
 
     /// <summary>
@@ -120,39 +120,39 @@ public class ASActor : ASObject
     }
 }
 
-/// <inheritdoc cref="ASActor" />
+/// <inheritdoc cref="APActor" />
 [ImpliesOtherEntity(typeof(ASObjectEntity))]
-public sealed class ASActorEntity : ASEntity<ASActor>
+public sealed class APActorEntity : ASEntity<APActor>
 {
-    /// <inheritdoc cref="ASActor.Inbox" />
+    /// <inheritdoc cref="APActor.Inbox" />
     [JsonPropertyName("inbox")]
     public required ASLink Inbox { get; set; }
 
-    /// <inheritdoc cref="ASActor.Outbox" />
+    /// <inheritdoc cref="APActor.Outbox" />
     [JsonPropertyName("outbox")]
     public required ASLink Outbox { get; set; }
 
-    /// <inheritdoc cref="ASActor.Following" />
+    /// <inheritdoc cref="APActor.Following" />
     [JsonPropertyName("following")]
     public ASLink? Following { get; set; }
 
-    /// <inheritdoc cref="ASActor.Followers" />
+    /// <inheritdoc cref="APActor.Followers" />
     [JsonPropertyName("followers")]
     public ASLink? Followers { get; set; }
 
-    /// <inheritdoc cref="ASActor.Liked" />
+    /// <inheritdoc cref="APActor.Liked" />
     [JsonPropertyName("liked")]
     public ASLink? Liked { get; set; }
 
-    /// <inheritdoc cref="ASActor.Streams" />
+    /// <inheritdoc cref="APActor.Streams" />
     [JsonPropertyName("streams")]
     public ASType? Streams { get; set; }
 
-    /// <inheritdoc cref="ASActor.PreferredUsername" />
+    /// <inheritdoc cref="APActor.PreferredUsername" />
     [JsonPropertyName("preferredUsername")]
     public NaturalLanguageString? PreferredUsername { get; set; }
 
-    /// <inheritdoc cref="ASActor.Endpoints" />
+    /// <inheritdoc cref="APActor.Endpoints" />
     [JsonPropertyName("endpoints")]
     public Linkable<ActorEndpoints>? Endpoints { get; set; }
 }

--- a/ActivityPub.Types/AS/ASObject.cs
+++ b/ActivityPub.Types/AS/ASObject.cs
@@ -280,7 +280,7 @@ public class ASObject : ASType
     ///     This is a list of all Like activities with this object as the object property, added as a side effect.
     /// </summary>
     /// <remarks>
-    ///     Care should be taken to not confuse the the likes collection with the similarly named but different <see cref="ASActor.Liked" /> collection.
+    ///     Care should be taken to not confuse the the likes collection with the similarly named but different <see cref="APActor.Liked" /> collection.
     /// </remarks>
     /// <seealso href="https://www.w3.org/TR/activitypub/#likes" />
     public Linkable<ASCollection>? Likes
@@ -411,11 +411,11 @@ public sealed class ASObjectEntity : ASEntity<ASObject>, ISubTypeDeserialized
 
     public static bool TryNarrowTypeByJson(JsonElement element, DeserializationMetadata meta, [NotNullWhen(true)] out Type? type)
     {
-        // Infer ASActor.
+        // Infer APActor.
         // This improves ergonomics when a regular object is used as an actor.
         if (element.HasProperty("inbox") && element.HasProperty("outbox"))
         {
-            type = typeof(ASActorEntity);
+            type = typeof(APActorEntity);
             return true;
         }
 

--- a/ActivityPub.Types/AS/Extended/Actor/ApplicationActor.cs
+++ b/ActivityPub.Types/AS/Extended/Actor/ApplicationActor.cs
@@ -8,7 +8,7 @@ namespace ActivityPub.Types.AS.Extended.Actor;
 /// <summary>
 ///     Describes a software application.
 /// </summary>
-public class ApplicationActor : ASActor
+public class ApplicationActor : APActor
 {
     public ApplicationActor() => Entity = new ApplicationActorEntity { TypeMap = TypeMap };
     public ApplicationActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<ApplicationActorEntity>();
@@ -17,7 +17,7 @@ public class ApplicationActor : ASActor
 
 /// <inheritdoc cref="ApplicationActor" />
 [APConvertible(ApplicationType)]
-[ImpliesOtherEntity(typeof(ASActorEntity))]
+[ImpliesOtherEntity(typeof(APActorEntity))]
 public sealed class ApplicationActorEntity : ASEntity<ApplicationActor>
 {
     public const string ApplicationType = "Application";

--- a/ActivityPub.Types/AS/Extended/Actor/GroupActor.cs
+++ b/ActivityPub.Types/AS/Extended/Actor/GroupActor.cs
@@ -8,7 +8,7 @@ namespace ActivityPub.Types.AS.Extended.Actor;
 /// <summary>
 ///     Represents a formal or informal collective of Actors.
 /// </summary>
-public class GroupActor : ASActor
+public class GroupActor : APActor
 {
     public GroupActor() => Entity = new GroupActorEntity { TypeMap = TypeMap };
     public GroupActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<GroupActorEntity>();
@@ -17,7 +17,7 @@ public class GroupActor : ASActor
 
 /// <inheritdoc cref="GroupActor" />
 [APConvertible(GroupType)]
-[ImpliesOtherEntity(typeof(ASActorEntity))]
+[ImpliesOtherEntity(typeof(APActorEntity))]
 public sealed class GroupActorEntity : ASEntity<GroupActor>
 {
     public const string GroupType = "Group";

--- a/ActivityPub.Types/AS/Extended/Actor/OrganizationActor.cs
+++ b/ActivityPub.Types/AS/Extended/Actor/OrganizationActor.cs
@@ -8,7 +8,7 @@ namespace ActivityPub.Types.AS.Extended.Actor;
 /// <summary>
 ///     Represents an organization.
 /// </summary>
-public class OrganizationActor : ASActor
+public class OrganizationActor : APActor
 {
     public OrganizationActor() => Entity = new OrganizationActorEntity { TypeMap = TypeMap };
     public OrganizationActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<OrganizationActorEntity>();
@@ -17,7 +17,7 @@ public class OrganizationActor : ASActor
 
 /// <inheritdoc cref="OrganizationActor" />
 [APConvertible(OrganizationType)]
-[ImpliesOtherEntity(typeof(ASActorEntity))]
+[ImpliesOtherEntity(typeof(APActorEntity))]
 public sealed class OrganizationActorEntity : ASEntity<OrganizationActor>
 {
     public const string OrganizationType = "Organization";

--- a/ActivityPub.Types/AS/Extended/Actor/PersonActor.cs
+++ b/ActivityPub.Types/AS/Extended/Actor/PersonActor.cs
@@ -8,7 +8,7 @@ namespace ActivityPub.Types.AS.Extended.Actor;
 /// <summary>
 ///     Represents an individual person.
 /// </summary>
-public class PersonActor : ASActor
+public class PersonActor : APActor
 {
     public PersonActor() => Entity = new PersonActorEntity { TypeMap = TypeMap };
     public PersonActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<PersonActorEntity>();
@@ -17,7 +17,7 @@ public class PersonActor : ASActor
 
 /// <inheritdoc cref="PersonActor" />
 [APConvertible(PersonType)]
-[ImpliesOtherEntity(typeof(ASActorEntity))]
+[ImpliesOtherEntity(typeof(APActorEntity))]
 public sealed class PersonActorEntity : ASEntity<PersonActor>
 {
     public const string PersonType = "Person";

--- a/ActivityPub.Types/AS/Extended/Actor/ServiceActor.cs
+++ b/ActivityPub.Types/AS/Extended/Actor/ServiceActor.cs
@@ -8,7 +8,7 @@ namespace ActivityPub.Types.AS.Extended.Actor;
 /// <summary>
 ///     Represents a service of any kind.
 /// </summary>
-public class ServiceActor : ASActor
+public class ServiceActor : APActor
 {
     public ServiceActor() => Entity = new ServiceActorEntity { TypeMap = TypeMap };
     public ServiceActor(TypeMap typeMap) : base(typeMap) => Entity = TypeMap.AsEntity<ServiceActorEntity>();
@@ -17,7 +17,7 @@ public class ServiceActor : ASActor
 
 /// <inheritdoc cref="ServiceActor" />
 [APConvertible(ServiceType)]
-[ImpliesOtherEntity(typeof(ASActorEntity))]
+[ImpliesOtherEntity(typeof(APActorEntity))]
 public sealed class ServiceActorEntity : ASEntity<ServiceActor>
 {
     public const string ServiceType = "Service";

--- a/ActivityPub.Types/readme.md
+++ b/ActivityPub.Types/readme.md
@@ -19,7 +19,7 @@ Types are implemented as classes and grouped as follows:
 * [`ActivityPub.Types.AS.Collection`](AS/Collection) - Collection / page types.
 * [`ActivityPub.Types.AS.Extended.Object`](AS/Extended/Object) - Extended Object types. These all derive from [`ASObject`](AS/ASObject.cs).
 * [`ActivityPub.Types.AS.Extended.Link`](AS/Extended/Link) - Extended Link types. These all derive from [`ASLink`](AS/ASLink.cs).
-* [`ActivityPub.Types.AS.Extended.Actor`](AS/Extended/Actor) - Extended Actor types. These all derive from [`ASActor`](AS/ASActor.cs).
+* [`ActivityPub.Types.AS.Extended.Actor`](AS/Extended/Actor) - Extended Actor types. These all derive from [`APActor`](AS/APActor.cs).
 * [`ActivityPub.Types.AS.Extended.Activity`](AS/Extended/Activity) - Extended Activity types. These all derive from [`ASActivity`](AS/ASActivity.cs) or one of the synthetic types described below.
 
 ## Synthetic Types
@@ -28,7 +28,7 @@ To improve developer experience, a few synthetic intermediate types have been in
 These are as follows:
 
 * [`ASType`](AS/ASType.cs) - a common type between [`Link`](AS/ASLink.cs) and [`Object`](AS/ASObject.cs). This enables support for the `Range: Link | Object` construction that is common within the ActivityStreams specification.
-* [`ASActor`](AS/ASActor.cs) - base type for Actor objects. Defined object types may extend this directly, and any other compatible object (includes Inbox and Outbox) will be "promoted" to include this as a standalone.
+* [`APActor`](AS/APActor.cs) - base type for Actor objects. Defined object types may extend this directly, and any other compatible object (includes Inbox and Outbox) will be "promoted" to include this as a standalone.
 * [`ASTransitiveActivity`](AS/ASTransitiveActivity.cs) - a mirror to [`IntransitiveActivity`](AS/ASIntransitiveActivity.cs) that implies just the opposite. Transitive activities support the [`object` property](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-object).
 * [`ASTargetedActivity`](AS/ASTargetedActivity.cs) - extension of `TransitiveActivity` for activities which contain a [`target` property](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-target).
 

--- a/Tests/ActivityPub.Types.Tests/Integration/Deserialization/ActorDeserializationTests.cs
+++ b/Tests/ActivityPub.Types.Tests/Integration/Deserialization/ActorDeserializationTests.cs
@@ -7,7 +7,7 @@ using ActivityPub.Types.Tests.Util.Fixtures;
 
 namespace ActivityPub.Types.Tests.Integration.Deserialization;
 
-public abstract class ActorDeserializationTests : DeserializationTests<ASActor>
+public abstract class ActorDeserializationTests : DeserializationTests<APActor>
 {
     private ActorDeserializationTests(JsonLdSerializerFixture fixture) : base(fixture) {}
 
@@ -86,7 +86,7 @@ public abstract class ActorDeserializationTests : DeserializationTests<ASActor>
                             }
                             """;
 
-            ObjectUnderTest.Is<ASActor>().Should().BeTrue();
+            ObjectUnderTest.Is<APActor>().Should().BeTrue();
         }
     }
 }

--- a/Tests/ActivityPub.Types.Tests/Integration/Serialization/SimpleObjectSerializationTests.cs
+++ b/Tests/ActivityPub.Types.Tests/Integration/Serialization/SimpleObjectSerializationTests.cs
@@ -68,7 +68,7 @@ public abstract class SimpleObjectSerializationTests : SerializationTests
         {
             ObjectUnderTest = new PersonActor
             {
-                // From ASActor
+                // From APActor
                 Inbox = "https://example.com/actor/inbox",
                 Outbox = "https://example.com/actor/outbox",
 

--- a/Tests/ActivityPub.Types.Tests/Unit/AS/ASObjectEntityTests.cs
+++ b/Tests/ActivityPub.Types.Tests/Unit/AS/ASObjectEntityTests.cs
@@ -19,12 +19,12 @@ public abstract class ASObjectEntityTests
         };
 
         [Fact]
-        public void ReturnASActor_WhenJsonHasInboxAndOutbox()
+        public void ReturnAPActor_WhenJsonHasInboxAndOutbox()
         {
             var json = JsonSerializer.SerializeToElement(new { inbox = "i", outbox = "o" });
             var result = ASObjectEntity.TryNarrowTypeByJson(json, _stubMetadata, out var type);
             result.Should().BeTrue();
-            type.Should().Be(typeof(ASActorEntity));
+            type.Should().Be(typeof(APActorEntity));
         }
 
         [Fact]


### PR DESCRIPTION
In this PR I changed all references to `ASActor` and `ASActorEntity` to `APActor` and `APActorEntity` respectively.

Tests and README have also been updated.

Now, I opened this PR as a draft because I not quite sure on how to proceed with the folder structure: as of right now the APActor.cs file is inside the AS folder which obviously refers to ActivityStreams, shall we move the APActor.cs file to an AP folder or leave it as it is for now? What do you thing @warriordog ?

Closes #57 