### PR TITLE
InReplyTo as LinkableList

### DIFF
--- a/Source/ActivityPub.Types/AS/ASObject.cs
+++ b/Source/ActivityPub.Types/AS/ASObject.cs
@@ -150,7 +150,7 @@ public class ASObject : ASType, IASModel<ASObject, ASObjectEntity, ASType>
     ///     Indicates one or more entities for which this object is considered a response.
     /// </summary>
     /// <seealso href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-inReplyTo" />
-    public Linkable<ASObject>? InReplyTo
+    public LinkableList<ASObject>? InReplyTo
     {
         get => Entity.InReplyTo;
         set => Entity.InReplyTo = value;
@@ -366,7 +366,7 @@ public sealed class ASObjectEntity : ASEntity<ASObject, ASObjectEntity>, IJsonOn
 
     /// <inheritdoc cref="ASObject.InReplyTo" />
     [JsonPropertyName("inReplyTo")]
-    public Linkable<ASObject>? InReplyTo { get; set; }
+    public LinkableList<ASObject>? InReplyTo { get; set; }
 
     /// <inheritdoc cref="ASObject.Location" />
     [JsonPropertyName("location")]


### PR DESCRIPTION
Personally, I think it makes no sense, but the spec says inReplyTo can be a list. Which turns out to matter, because FedBOX uses a list (pretty sure it's a list, not a collection) of posts to capture the entire up-thread reply chain. And Letterbook would preferably understand that, so we have to parse that list.

This thread has a little more context.
https://metalhead.club/@mariusor/111716426804127782